### PR TITLE
(#10)カードの基本クラスとデッククラスのシーンの対応

### DIFF
--- a/src/scenes/mainScene.ts
+++ b/src/scenes/mainScene.ts
@@ -45,6 +45,7 @@ export class BlackJackScene extends Phaser.Scene{
     create(){
         // deckをシャッフル
         this.deck.shuffle()
+        //フレームを取得
         const frames = this.cardScene.textures.get(atlasText).getFrameNames();
 
     }


### PR DESCRIPTION


## 目的
カードに対応した画像の表示
## 達成条件
カードを配布, flip のアニメーションを実装
## 実装の概要
atlasを読み込みカードクラスから対応するカードを表示まで出来た
##  レビューして欲しいところ
CardSceneでアトラス画像を読み込んでいるが、それだけなので拡張性を持たせたい
##  保留, 悩んでいる所
アニメーションの付加方法
どうやって座標指定などをしよう悩み中。
